### PR TITLE
Removed the display of the game server month due to incorrect values,…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ls25-discord-bot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A simple discord bot for farming simulator 25",
   "main": "source/Main.ts",
   "scripts": {

--- a/source/Services/DiscordEmbed.ts
+++ b/source/Services/DiscordEmbed.ts
@@ -100,8 +100,6 @@ export default class DiscordEmbed {
         let embed = new EmbedBuilder();
         let config = this.appConfiguration;
 
-        serverStats.getServerMonth();
-
         embed.setTitle(config.translation.discordEmbed.title);
         if (!serverStats.isOnline()) {
             embed.setColor(0xCA0000);

--- a/source/Services/ServerStatusFeed.ts
+++ b/source/Services/ServerStatusFeed.ts
@@ -138,37 +138,6 @@ export default class ServerStatusFeed {
     }
 
     /**
-     * Returns the server month as a string
-     * @returns {string} The server month as a string
-     */
-    public getServerMonth(): string {
-        let config: IConfiguration = Configuration.getConfiguration();
-        let dayTime = this.getServerStats()?.Server.dayTime;
-        if (dayTime === undefined) {
-            return "Error";
-        }
-        let month = dayTime / (60 * 60 * 1000 * 24);
-        month = month % 1;
-        month = month * 12;
-        month = Math.floor(month);
-        let months = [
-            config.translation.common.monthJanuary,
-            config.translation.common.monthFebruary,
-            config.translation.common.monthMarch,
-            config.translation.common.monthApril,
-            config.translation.common.monthMay,
-            config.translation.common.monthJune,
-            config.translation.common.monthJuly,
-            config.translation.common.monthAugust,
-            config.translation.common.monthSeptember,
-            config.translation.common.monthOctober,
-            config.translation.common.monthNovember,
-            config.translation.common.monthDecember
-        ]
-        return months[month-1];
-    }
-
-    /**
      * Returns the server time in the format HH:MM
      * @returns {string} The server time in the format HH:MM
      */
@@ -187,7 +156,7 @@ export default class ServerStatusFeed {
         if(minutesString.length === 1) {
             minutesString = `0${minutesString}`;
         }
-        return `${hoursString}:${minutesString} (${this.getServerMonth()})`;
+        return `${hoursString}:${minutesString}`;
     }
 
     /**


### PR DESCRIPTION

This pull request includes several changes to the `ls25-discord-bot` project, primarily focusing on the removal of the `getServerMonth` method and related references, as well as a version bump in the `package.json` file.

Codebase simplification:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.1.6` to `0.1.7`.
* [`source/Services/DiscordEmbed.ts`](diffhunk://#diff-8149e3df590f14f1ab0f776dd0a45c26618dee4ecff581b08c3824e4ab22a0c3L103-L104): Removed the call to `serverStats.getServerMonth()` from the `DiscordEmbed` class.
* [`source/Services/ServerStatusFeed.ts`](diffhunk://#diff-605c37119b538f471c30aaebbcb8e1a6f34ee2ad8c8e1fd07deafefa19591c92L140-L170): Removed the `getServerMonth` method, which included logic to calculate the server month as a string.
* [`source/Services/ServerStatusFeed.ts`](diffhunk://#diff-605c37119b538f471c30aaebbcb8e1a6f34ee2ad8c8e1fd07deafefa19591c92L190-R159): Updated the `getServerTime` method to no longer include the server month in the returned string.